### PR TITLE
Add support for calling DebugGUI from GDScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ Persistent logs may also be managed manually in the same way as graphs using arb
     }
 ```
 
+## GDScript Support
+
+Using DebugGUI Graph from GDScript requires Godot 4.2. GDScript does not support C#-style attribues, however the static methods of `DebugGUI` can be used manually from GDScript.
+
+```python
+func _ready():
+    DebugGUI.SetGraphProperties(self, "MyObject", 0.0, 10.0, 1, Color.WHITE, true)
+
+func _process(_delta):
+    DebugGUI.Graph(self, self.linear_velocity.length())
+```
+
 ## Contribution
 If you spot a bug while using this, please create an [Issue](https://github.com/WeaverDev/DebugGUIGraph/issues).
 

--- a/addons/DebugGUI/DebugGUI.cs
+++ b/addons/DebugGUI/DebugGUI.cs
@@ -117,6 +117,20 @@ public partial class DebugGUI : Control
     }
 
     /// <summary>
+    /// Set the properties of a graph.
+    /// </summary>
+    /// <param name="key">The graph's key</param>
+    /// <param name="label">The graph's label</param>
+    /// <param name="min">Value at the bottom of the graph box</param>
+    /// <param name="max">Value at the top of the graph box</param>
+    /// <param name="group">The graph's ordinal position on screen</param>
+    /// <param name="color">The graph's color</param>
+    public static void SetGraphProperties(GodotObject key, string label, float min, float max, int group, Color color, bool autoScale)
+    {
+        SetGraphProperties((object)key, label, min, max, group, color, autoScale);
+    }
+
+    /// <summary>
     /// Add a data point to a graph.
     /// </summary>
     /// <param name="key">The graph's key</param>
@@ -125,6 +139,16 @@ public partial class DebugGUI : Control
     {
         if (Settings.enableGraphs)
             Instance?.graphWindow.Graph(key, val);
+    }
+
+    /// <summary>
+    /// Add a data point to a graph.
+    /// </summary>
+    /// <param name="key">The graph's key</param>
+    /// <param name="val">Value to be added</param>
+    public static void Graph(GodotObject key, float val)
+    {
+        Graph((object)key, val);
     }
 
     /// <summary>
@@ -138,6 +162,15 @@ public partial class DebugGUI : Control
     }
 
     /// <summary>
+    /// Remove an existing graph.
+    /// </summary>
+    /// <param name="key">The graph's key</param>
+    public static void RemoveGraph(GodotObject key)
+    {
+        RemoveGraph((object)key);
+    }
+
+    /// <summary>
     /// Resets a graph's data.
     /// </summary>
     /// <param name="key">The graph's key</param>
@@ -145,6 +178,15 @@ public partial class DebugGUI : Control
     {
         if (Settings.enableGraphs)
             Instance?.graphWindow.ClearGraph(key);
+    }
+
+    /// <summary>
+    /// Resets a graph's data.
+    /// </summary>
+    /// <param name="key">The graph's key</param>
+    public static void ClearGraph(GodotObject key)
+    {
+        ClearGraph((object)key);
     }
 
     /// <summary>
@@ -188,12 +230,28 @@ public partial class DebugGUI : Control
     }
 
     /// <summary>
+    /// Create or update an existing message with the same key.
+    /// </summary>
+    public static void LogPersistent(GodotObject key, string message)
+    {
+        LogPersistent((object)key, message);
+    }
+
+    /// <summary>
     /// Remove an existing persistent message.
     /// </summary>
     public static void RemovePersistent(object key)
     {
         if (Settings.enableLogs)
             Instance?.logWindow.RemovePersistent(key);
+    }
+
+    /// <summary>
+    /// Remove an existing persistent message.
+    /// </summary>
+    public static void RemovePersistent(GodotObject key)
+    {
+        RemovePersistent((object)key);
     }
 
     /// <summary>
@@ -210,8 +268,24 @@ public partial class DebugGUI : Control
     /// </summary>
     public static void Log(object message)
     {
+        Log(message.ToString());
+    }
+
+    /// <summary>
+    /// Print a temporary message.
+    /// </summary>
+    public static void Log(GodotObject message)
+    {
+        Log(message.ToString());
+    }
+
+    /// <summary>
+    /// Print a temporary message.
+    /// </summary>
+    public static void Log(string message)
+    {
         if (Settings.enableLogs)
-            Instance?.logWindow.Log(message.ToString());
+            Instance?.logWindow.Log(message);
     }
 
     #endregion


### PR DESCRIPTION
When trying to call the static methods of `DebugGUI` from GDScript, Godot throws the following error:

```
Invalid call. Nonexistent function 'SetGraphProperties' in base 'Control (DebugGUI.cs)'.
```

This is due to the use of `object` as a parameter type, which Godot seems unable to automatically convert GDScript objects to. This PR adds overloads to the static methods of `DebugGUI` which use `GodotObject` as a parameter type, allowing these methods to be called from GDScript.