### PR TITLE
Fix DebugGUIPrint for multiple properties on the same node

### DIFF
--- a/addons/DebugGUI/Windows/LogWindow.cs
+++ b/addons/DebugGUI/Windows/LogWindow.cs
@@ -46,7 +46,7 @@ namespace WeavUtils
             }
             transientLogs.RemoveRange(0, expiredCt);
 
-            if (persistentLogs.Count + transientLogs.Count > 0)
+            if (debugGUIPrintFields.Count + debugGUIPrintProperties.Count + persistentLogs.Count + transientLogs.Count > 0)
             {
                 QueueRedraw();
             }
@@ -235,7 +235,7 @@ namespace WeavUtils
                     if (Attribute.GetCustomAttribute(objectProperties[i], typeof(DebugGUIPrintAttribute)) is DebugGUIPrintAttribute)
                     {
                         uniqueAttributeContainers.Add(node);
-                        typeCache.Add(node, node.GetType());
+                        typeCache[node] = node.GetType();
 
                         if (!debugGUIPrintProperties.ContainsKey(nodeType))
                         {


### PR DESCRIPTION
`typeCache.Add(node, node.GetType());` in `LogWindow.RegisterAttributes` throws an error if the node already exists in the dictionary, which happens if there are multiple properties with the `DebugGUIPrint` attribute on the same node. This doesn't occur with fields because they use `typeCache[node] = node.GetType();` instead. This PR updates the code for attributes to do the same.

This also fixes a bug causing the `LogWindow` to never redraw if there are no log messages besides those generated by the `DebugGUIPrint` attribute.