### PR TITLE
Make GraphWindow and LogWindow follow the active camera

### DIFF
--- a/addons/DebugGUI/DebugGUI.cs
+++ b/addons/DebugGUI/DebugGUI.cs
@@ -303,11 +303,15 @@ public partial class DebugGUI : Control
 
         if (Settings.enableGraphs)
         {
-            AddChild(graphWindow = new());
+            CanvasLayer canvasLayer = new();
+            canvasLayer.AddChild(graphWindow = new());
+            AddChild(canvasLayer);
         }
         if (Settings.enableGraphs)
         {
-            AddChild(logWindow = new());
+            CanvasLayer canvasLayer = new();
+            canvasLayer.AddChild(logWindow = new());
+            AddChild(canvasLayer);
         }
     }
 }


### PR DESCRIPTION
Currently, the graph and log windows are anchored to have top left at global world coordinates of (0,0). That is fine until adding an active Camera2D to the scene.

This PR puts the graph and log windows inside CanvasLayers which will keep them at the top left of the screen regardless of the existence of a Camera2D.