### PR TITLE
Don't print nodes on init

### DIFF
--- a/addons/DebugGUI/Windows/GraphWindow.cs
+++ b/addons/DebugGUI/Windows/GraphWindow.cs
@@ -376,7 +376,7 @@ namespace WeavUtils
         {
             foreach (Node child in node.GetChildren())
             {
-                GD.Print(child);
+                // GD.Print(child);
                 RegisterAttributes(child);
             }
 

--- a/addons/DebugGUI/Windows/LogWindow.cs
+++ b/addons/DebugGUI/Windows/LogWindow.cs
@@ -192,7 +192,7 @@ namespace WeavUtils
         {
             foreach (Node child in node.GetChildren())
             {
-                GD.Print(child);
+                // GD.Print(child);
                 RegisterAttributes(child);
             }
 


### PR DESCRIPTION
Stops output log being spammed every time you load a scene